### PR TITLE
Update xfce4-power-manager.xml with presentation mode

### DIFF
--- a/provisioning/kali/generic/xfce4-power-manager.xml
+++ b/provisioning/kali/generic/xfce4-power-manager.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.1" encoding="UTF-8"?>
 <channel name="xfce4-power-manager" version="1.0">
   <property name="xfce4-power-manager" type="empty">
     <property name="power-button-action" type="empty"/>
@@ -10,5 +10,9 @@
     <property name="blank-on-ac" type="int" value="0"/>
     <property name="dpms-on-ac-sleep" type="uint" value="0"/>
     <property name="dpms-on-ac-off" type="uint" value="0"/>
+    <property name="lock-screen-suspend-hibernate" type="bool" value="true"/>
+    <property name="show-tray-icon" type="bool" value="false"/>
+    <property name="inactivity-on-ac" type="uint" value="0"/>
+    <property name="presentation-mode" type="bool" value="true"/>
   </property>
 </channel>


### PR DESCRIPTION
added property presentation-mode in the power manager of xfce4 with true value to keep the screen unlocked